### PR TITLE
Link styles and resets

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,6 +1,6 @@
 *,
-::before,
-::after {
+*::before,
+*::after {
   box-sizing: border-box;
 
   @media (prefers-reduced-motion: reduce) {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -16,11 +16,6 @@
   }
 }
 
-html,
-body {
-  height: 100%;
-}
-
 html {
   background: var(--color-background-secondary);
   scroll-padding-top: 5rem;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -16,6 +16,11 @@
   }
 }
 
+html,
+body {
+  height: 100%;
+}
+
 html {
   background: var(--color-background-secondary);
   scroll-padding-top: 5rem;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -30,7 +30,7 @@ body {
   background-color: var(--color-background);
 }
 
-a {
+:any-link {
   position: relative;
 
   &:link,

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -84,6 +84,7 @@ h6,
   font-weight: $font-weight-bold;
   font-family: $font-body;
   line-height: $line-height-heading;
+  overflow-wrap: break-word;
 
   :any-link {
     text-decoration: none;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -85,8 +85,7 @@ h6,
   font-family: $font-body;
   line-height: $line-height-heading;
 
-  a:link,
-  a:visited {
+  :any-link {
     text-decoration: none;
   }
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -32,16 +32,11 @@ body {
 
 :any-link {
   position: relative;
+  text-decoration: underline;
 
   &:link,
   &:visited {
     color: var(--color-link);
-    text-decoration: underline;
-  }
-
-  &:hover,
-  &:focus {
-    text-decoration: underline;
   }
 
   &:hover {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -209,12 +209,13 @@ hr {
 }
 
 img,
+picture,
 svg,
 video,
 canvas {
+  display: block;
   max-width: 100%;
   height: auto;
-  vertical-align: middle;
   border: 0;
 }
 

--- a/_sass/_junkdrawer.scss
+++ b/_sass/_junkdrawer.scss
@@ -38,6 +38,7 @@
 }
 
 .svg-icon {
+  display: inline-block;
   width: 1rem;
   height: 1rem;
   color: var(--color-text-accent);

--- a/_sass/_junkdrawer.scss
+++ b/_sass/_junkdrawer.scss
@@ -69,7 +69,7 @@
     color: var(--color-border);
   }
 
-  a {
+  :any-link {
     &:link,
     &:visited {
       color: var(--color-border);
@@ -93,7 +93,7 @@
     }
   }
 
-  .site-footer-logo a {
+  .site-footer-logo :any-link {
     font-weight: $font-weight-black;
   }
 }
@@ -101,7 +101,7 @@
 .social-media-list {
   @extend %unlist;
 
-  a {
+  :any-link {
     display: inline-block;
     margin-bottom: 0.25rem;
   }


### PR DESCRIPTION
This PR replaces references to `<a>` in our SCSS with `:any-link`. Using `:any-link` avoids `<a>` elements that do not have `href` attributes and lowers the specificity of link styles, overall. [IE 11 doesn't support this pseudo selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link#browser_compatibility), but that's ok based on [our support matrix](https://github.com/double-great/theme/blob/main/.browserslistrc).

I spotted this on [When to Avoid the text-decoration Shorthand Property](https://css-tricks.com/when-to-avoid-css-text-decoration-shorthand/):
>Throughout this article, I will use the :any-link selector instead of the a element to match hyperlinks. The problem with the a tag as a selector is that it matches all <a> elements, even the ones that don’t have a href attribute and thus [aren’t hyperlinks](https://www.tempertemper.net/blog/links-missing-href-attributes-and-over-engineered-code). The :any-link selector only matches <a> elements that are hyperlinks. Web browsers also use :any-link instead of a in their user agent stylesheets.

This also incorporates a few reset rules from [Josh Comeau's CSS reset](https://www.joshwcomeau.com/css/custom-css-reset/) with more context from [CSS Tricks: Notes on Josh Comeau’s Custom CSS Reset](https://css-tricks.com/notes-on-josh-comeaus-custom-css-reset/). Namely:
- Setting image-like elements to `display: block;`
- Adding `overflow-wrap: break-word;` to H1-H6

I also caught a mistake in the universal selector I wrote originally. I had `*, ::before, ::after` instead of `*, *::before, *::after`.