### PR TITLE
Focus visible

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -115,7 +115,7 @@
     "selector-max-compound-selectors": 4,
     "selector-max-empty-lines": 0,
     "selector-max-id": 0,
-    "selector-max-pseudo-class": 2,
+    "selector-max-pseudo-class": 5,
     "selector-max-specificity": "0,4,2",
     "selector-max-type": 3,
     "selector-max-universal": 2,

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -39,11 +39,20 @@ body {
     color: var(--color-link);
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     color: var(--color-link-hover);
   }
 
-  &:focus {
+  // avoid flash of focus state on click
+  // stylelint-disable a11y/no-outline-none
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+  // stylelint-enable a11y/no-outline-none
+
+  // ensure focus state for keyboard nav
+  &:focus-visible {
     @include focus-with-shadow;
   }
 


### PR DESCRIPTION
This replaces our `:focus` state with `:focus-visible` and zeroes out `:focus` so that clicking a link stops flashing the focus state. This ensures that keyboard navigation still sees the designed focus state.

[CSS Tricks: The Focus Visible Trick](https://css-tricks.com/the-focus-visible-trick/) gives some more detail.

Before — clicking a link with `:focus` styles

https://user-images.githubusercontent.com/1215760/161873057-bb0ad876-e2d9-4243-9519-758ab5cf1a39.mov

After — clicking a link with `:focus-visible` styles and `:focus` reset

https://user-images.githubusercontent.com/1215760/161873189-ab4596a5-39a7-450d-8bc6-2c5a2606cd86.mov


