### PR TITLE
Adding dynamic link to color contrast grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,15 @@ title: Style guide
 layout: page
 ---
 
-<h2 id="variables">Variables</h2>
+<h2 id="contrast">Color contrast</h2>
+<p>Check out a <a href="https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=&foreground-colors={%-for key in site.data.variables-%}
+    {%-assign varName = key[0]-%}
+    {%-assign varValue = key[1]-%}
+    {%-if varName contains '$color-'-%}{{varValue | replace: "#", "%23"}}%2C%20{{varName | replace: "$color-", ""}}%0D%0A
+    {%-endif-%}
+{%-endfor-%}&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa">grid of color contrast values across this theme’s palette</a> using the excellent EightShapes Contrast Grid.</p>
 
+<h2 id="variables">Variables</h2>
 <table class="style-table">
   <thead><tr><th class="fix" scope="col">Variable name</th><th scope="col">Value</th></tr></thead>
   <tbody>


### PR DESCRIPTION
The [EightShapes Contrast Grid](https://contrast-grid.eightshapes.com) is a great way to visualize the color contrast between all colors in your palette. 

![Screenshot of the EightShapes Contrast Grid online tool](https://user-images.githubusercontent.com/1215760/198749941-2d97b5c7-350d-4947-a658-361fcfccf7d0.jpg)

When you land on that page, you'll notice that the URL expands to the very hack-friendly convention of: `https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=&foreground-colors=%23FFFFFF%2C%20White%0D%0A%23F2F2F2%0D%0A%23DDDDDD%0D%0A%23CCCCCC%0D%0A%23888888%0D%0A%23404040%2C%20Charcoal%0D%0A%23000000%2C%20Black%0D%0A%232F78C5%2C%20Effective%20on%20Extremes%0D%0A%230F60B6%2C%20Effective%20on%20Lights%0D%0A%23398EEA%2C%20Ineffective%0D%0A&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18&es-color-form__show-contrast=dnp`.

In this PR, I did a little string work on our `variable.json` file to generate a custom EightShapes Contrast Grid URL link at the top of the [theme styleguide page](https://doublegreat.dev/theme/) so we can visualize the color palette as it exists at any point in time.

![Screenshot of the contrast grid of the @double-great theme palette](https://user-images.githubusercontent.com/1215760/198750252-aaa3dafb-6189-4074-b50c-0036c938c09b.jpg)

I'm 100% sure there is a more elegant way to write that liquid spill that powers this feature. If you have any suggestions for refactoring, I would be very receptive :) 