### PR TITLE
CSS inline

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,19 +1,12 @@
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  {%- seo -%}
-  <link rel="preload" href="{{ '/assets/fonts/Inter.var.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin>
-  <link
-    rel="stylesheet"
-    href="{{ '/assets/main.css' |
-  relative_url}}"
-  />
-  <link
-    rel="shortcut icon"
-    href="{{ '/assets/favicon.ico' |
-  relative_url }}"
-    type="image/x-icon"
-  />
-  {%- feed_meta -%} {%- if site.custom_head %}{{site.custom_head}}{%- endif -%}
-  {%- if page.css -%}<style>{{page.css}}</style>{%- endif -%}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{%- seo -%}
+<link rel="preload" href="{{ '/assets/fonts/Inter.var.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin>
+<link rel="shortcut icon" href="{{ '/assets/favicon.ico' | relative_url }}" type="image/x-icon">
+<base href="{{ site.url }}{{ site.baseurl }}/">
+{%- feed_meta -%} {%- if site.custom_head %}{{site.custom_head}}{%- endif -%}
+{% capture sass_file %}{% include main.scss %}{% endcapture %}
+<style>{{ sass_file | scssify }}</style>
+{%- if page.css -%}<style>{{page.css}}</style>{%- endif -%}
 </head>

--- a/_includes/main.scss
+++ b/_includes/main.scss
@@ -1,4 +1,1 @@
----
----
-
 @import "great-great";

--- a/_sass/_webfonts.scss
+++ b/_sass/_webfonts.scss
@@ -3,6 +3,6 @@
   font-style: normal;
   font-weight: 100 900;
   font-display: swap;
-  src: url("fonts/Inter.var.woff2") format("woff2");
+  src: url("assets/fonts/Inter.var.woff2") format("woff2");
   font-named-instance: "Regular"; // stylelint-disable-line property-no-unknown
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prettier": "prettier --write \"assets/*.js\"",
     "eslint": "eslint \"assets/*.js\"",
     "uglify": "uglifyjs assets/navigation.js -m -o _includes/nav.min.js",
-    "test": "npm run js && bundle exec jekyll build && npm run stylelint",
+    "test": "npm run js && npm run stylelint && bundle exec jekyll build",
     "pretty-quick": "pretty-quick",
     "stylelint": "npm run browser-list && stylelint  \"_sass/**/*.scss\" --fix && npm run tokenize",
     "lint": "npm run pretty-quick && npm run stylelint",


### PR DESCRIPTION
This inlines CSS and sets a `base` URL so that the relative webfont path in the CSS will behave predictably, regardless of `site.baseurl`.