### PR TITLE
Let's make this text accent 7:1 (AAA)

### DIFF
--- a/_data/variables.json
+++ b/_data/variables.json
@@ -12,7 +12,7 @@
   "$color-background-tertiary": "#f0f0f0",
   "$color-highlight": "#fd0",
   "$color-border": "#cbcbcb",
-  "$color-text-accent": "#757575",
+  "$color-text-accent": "#595959",
   "$color-text-body": "#333",
   "$color-text-heading": "#222",
   "$color-link": "#1e69cd",

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -17,7 +17,7 @@ $color-highlight: #fd0;
 $color-border: #cbcbcb;
 
 // Text
-$color-text-accent: #757575;
+$color-text-accent: #595959;
 $color-text-body: #333;
 $color-text-heading: #222;
 


### PR DESCRIPTION
After looking at [a post on the Listen site](https://doublegreat.dev/listen/punctuation-in-alt-text/), I noticed with a [QualWeb](dhttps://github.com/qualweb) scan in Chrome returned a failure on [Text has increased contrast](https://act-rules.github.io/rules/09o5cg). This failure seems to occur when the AAA requirement of 7:1 contrast ratio is unmet.

Now the text accent color is 7:1: `#595959` / `#FFFFFF`