### PR TITLE
Set up Ruby so complete build can be tested

### DIFF
--- a/.github/workflows/dependency-mgmt.yml
+++ b/.github/workflows/dependency-mgmt.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+          bundler-cache: true
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Follow up on #137 — Ruby and Bundler need to be installed first so that the entire site build can be tested.