### PR TITLE
Ignore Ruby directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site/
 .jekyll-cache
 .sass-cache
 node_modules/
+vendor/
+.bundle/


### PR DESCRIPTION
Ignore `vendor` and `.bundle` to avoid a landslide of changed files when running action added in #137 